### PR TITLE
GitCommitBear.py: Enforce single newline

### DIFF
--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -113,6 +113,11 @@ class GitCommitBear(GlobalBear):
             self.err('git:', repr(stderr))
             return
 
+        pos1 = stdout.find('\n')
+        shortlog1 = stdout[:pos1] if pos1 != -1 else stdout
+        body1 = stdout[pos1+1:] if pos1 != -1 else ''
+        print('run0:',[x for x in body1])
+
         stdout = stdout.rstrip('\n')
         pos = stdout.find('\n')
         shortlog = stdout[:pos] if pos != -1 else stdout
@@ -122,6 +127,9 @@ class GitCommitBear(GlobalBear):
             if not allow_empty_commit_message:
                 yield Result(self, 'HEAD commit has no message.')
             return
+
+        if body:
+             print('run:',[x for x in body])
 
         yield from self.check_shortlog(
             shortlog,
@@ -246,9 +254,12 @@ class GitCommitBear(GlobalBear):
                                'HEAD commit. Please add one.')
             return
 
+        print('body:',[x for x in body])
         if body[1] is '\n':
+            print('Y U do dis?? newline y??')
             yield Result(self, 'More than one newline found between '
                                'shortlog and body')
+            return
 
         if body_regex and not re.fullmatch(body_regex, body.strip()):
             yield Result(self, 'No match found in commit message for the '

--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -133,6 +133,10 @@ class GitCommitBear(GlobalBear):
             body,
             **self.get_issue_checks_metadata().filter_parameters(kwargs))
 
+        if body and body[1] is '\n':
+            yield Result(self, 'More than one newline between'
+                               ' shortlog and body')
+
     def check_shortlog(self, shortlog,
                        shortlog_length: int=50,
                        shortlog_regex: str='',

--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -133,10 +133,6 @@ class GitCommitBear(GlobalBear):
             body,
             **self.get_issue_checks_metadata().filter_parameters(kwargs))
 
-        if body and body[1] is '\n':
-            yield Result(self, 'More than one newline between'
-                               ' shortlog and body')
-
     def check_shortlog(self, shortlog,
                        shortlog_length: int=50,
                        shortlog_regex: str='',
@@ -249,6 +245,10 @@ class GitCommitBear(GlobalBear):
             yield Result(self, 'No newline found between shortlog and body at '
                                'HEAD commit. Please add one.')
             return
+
+        if body[1] is '\n':
+            yield Result(self, 'More than one newline found between '
+                               'shortlog and body')
 
         if body_regex and not re.fullmatch(body_regex, body.strip()):
             yield Result(self, 'No match found in commit message for the '

--- a/tests/vcs/git/GitCommitBearTest.py
+++ b/tests/vcs/git/GitCommitBearTest.py
@@ -288,6 +288,12 @@ class GitCommitBearTest(unittest.TestCase):
                              body_regex=r'TICKER\s*CLOSE\s+[1-9][0-9]*'), [])
         self.assert_no_msgs()
 
+    def test_extra_newlines_between_shortlog_and_body(self):
+        commit = 'Shortlog\n\n\nBody\n\nCloses #1010101'
+        self.git_commit(commit)
+        self.assertEqual(self.run_uut(),
+                         ['More than one newline between shortlog and body'])
+
     def test_check_issue_reference(self):
         # Commit with no remotes configured
         self.git_commit('Shortlog\n\n'

--- a/tests/vcs/git/GitCommitBearTest.py
+++ b/tests/vcs/git/GitCommitBearTest.py
@@ -289,7 +289,7 @@ class GitCommitBearTest(unittest.TestCase):
         self.assert_no_msgs()
 
     def test_extra_newlines_between_shortlog_and_body(self):
-        commit = 'Shortlog\n\n\n\n\nBody\n\nCloses #1010101'
+        commit = 'Shortlog\n\n\nBody\n\nCloses #1010101'
         commit1 = commit.rstrip('\n')
         pos = commit1.find('\n')
         shortlog = commit1[:pos] if pos != -1 else stdout

--- a/tests/vcs/git/GitCommitBearTest.py
+++ b/tests/vcs/git/GitCommitBearTest.py
@@ -290,9 +290,18 @@ class GitCommitBearTest(unittest.TestCase):
 
     def test_extra_newlines_between_shortlog_and_body(self):
         commit = 'Shortlog\n\n\nBody\n\nCloses #1010101'
+        commit1 = commit.rstrip('\n')
+        pos = commit1.find('\n')
+        shortlog = commit1[:pos] if pos != -1 else stdout
+        body = commit1[pos+1:] if pos != -1 else ''
+        te = []
+        for char in body:
+            te.append(char)
+        print(te)
         self.git_commit(commit)
         self.assertEqual(self.run_uut(),
-                         ['More than one newline between shortlog and body'])
+                         ['More than one newline found between '
+                          'shortlog and body'])
 
     def test_check_issue_reference(self):
         # Commit with no remotes configured

--- a/tests/vcs/git/GitCommitBearTest.py
+++ b/tests/vcs/git/GitCommitBearTest.py
@@ -289,7 +289,7 @@ class GitCommitBearTest(unittest.TestCase):
         self.assert_no_msgs()
 
     def test_extra_newlines_between_shortlog_and_body(self):
-        commit = 'Shortlog\n\n\nBody\n\nCloses #1010101'
+        commit = 'Shortlog\n\n\n\n\nBody\n\nCloses #1010101'
         commit1 = commit.rstrip('\n')
         pos = commit1.find('\n')
         shortlog = commit1[:pos] if pos != -1 else stdout


### PR DESCRIPTION
Add check for single newline between
shortlog and body of commit message.

Closes https://github.com/coala/coala-bears/issues/1351

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
